### PR TITLE
Update environment/pom.xml  

### DIFF
--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -67,7 +67,7 @@
             <execution>
               <id>copy-resources</id>
               <!-- here the phase you need -->
-              <phase>compile</phase>
+              <phase>verify</phase>
               <goals>
                 <goal>copy-resources</goal>
               </goals>
@@ -114,7 +114,7 @@
             <execution>
               <id>copy-resources</id>
               <!-- here the phase you need -->
-              <phase>compile</phase>
+              <phase>verify</phase>
               <goals>
                 <goal>copy-resources</goal>
               </goals>


### PR DESCRIPTION
Update environment/pom.xml to change the maven phase for the maven-resources-plugin from compile to verify. If the plugin executes during compile phase the .properties file is only moved to the fabric8 folder after compilation, therefore the correct .properties file will not exist in the /target folder. If this the bundle is now deployed (fabric8:deploy) then the updated .properties file will not be present in the classpath and the fabric profile will not reflect the updated properties. Changing the phase to verify allows the .properties file to be updated before compilation, and the correct .properties file will be moved to the /target folder, and will therefore be available on the classpath when the bundle is deployed. 
